### PR TITLE
feat: expand BIM 3D viewer to fullscreen

### DIFF
--- a/src/app/components/bim-viewer/canvas-resize-sync.tsx
+++ b/src/app/components/bim-viewer/canvas-resize-sync.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useThree } from "@react-three/fiber";
+import { RefObject, useEffect } from "react";
+
+export function CanvasResizeSync({
+	rootRef,
+	isExpanded,
+}: {
+	rootRef: RefObject<HTMLElement | null>;
+	isExpanded: boolean;
+}) {
+	const setSize = useThree((state) => state.setSize);
+	const invalidate = useThree((state) => state.invalidate);
+
+	useEffect(() => {
+		const root = rootRef.current;
+		if (!root) return;
+
+		const sync = () => {
+			const { width, height } = root.getBoundingClientRect();
+			const w = Math.round(width);
+			const h = Math.round(height);
+			if (w > 0 && h > 0) {
+				setSize(w, h);
+				invalidate();
+			}
+		};
+
+		sync();
+		const rafId = requestAnimationFrame(sync);
+		const timeoutId = window.setTimeout(sync, 50);
+
+		const observer = new ResizeObserver(sync);
+		observer.observe(root);
+
+		return () => {
+			cancelAnimationFrame(rafId);
+			window.clearTimeout(timeoutId);
+			observer.disconnect();
+		};
+	}, [rootRef, isExpanded, setSize, invalidate]);
+
+	return null;
+}

--- a/src/app/components/bim-viewer/hooks/use-escape-key.ts
+++ b/src/app/components/bim-viewer/hooks/use-escape-key.ts
@@ -5,9 +5,12 @@ import { useEffect, RefObject } from "react";
 export function useEscapeKey(
 	containerRef: RefObject<HTMLDivElement | null>,
 	highlightedEntityIndices: Set<number>,
-	clearHighlight: () => void
+	clearHighlight: () => void,
+	isExpanded: boolean
 ) {
 	useEffect(() => {
+		if (isExpanded) return;
+
 		const el = containerRef.current;
 		if (!el) return;
 
@@ -19,5 +22,10 @@ export function useEscapeKey(
 		}
 		el.addEventListener("keydown", onKeyDown);
 		return () => el.removeEventListener("keydown", onKeyDown);
-	}, [containerRef, highlightedEntityIndices.size, clearHighlight]);
+	}, [
+		containerRef,
+		highlightedEntityIndices.size,
+		clearHighlight,
+		isExpanded,
+	]);
 }

--- a/src/app/components/bim-viewer/hooks/use-expanded-viewer.ts
+++ b/src/app/components/bim-viewer/hooks/use-expanded-viewer.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function useExpandedViewer(isExpanded: boolean, onCollapse: () => void) {
+	useEffect(() => {
+		if (!isExpanded) return;
+		const previousOverflow = document.body.style.overflow;
+		document.body.style.overflow = "hidden";
+		return () => {
+			document.body.style.overflow = previousOverflow;
+		};
+	}, [isExpanded]);
+
+	useEffect(() => {
+		if (!isExpanded) return;
+
+		function onKeyDown(e: KeyboardEvent) {
+			if (e.key === "Escape") {
+				e.preventDefault();
+				onCollapse();
+			}
+		}
+
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [isExpanded, onCollapse]);
+}

--- a/src/app/components/bim-viewer/index.tsx
+++ b/src/app/components/bim-viewer/index.tsx
@@ -112,13 +112,17 @@ export function BimViewer({ entityIndices }: { entityIndices: number[] }) {
 					onGhostToggle={toggleGhostOthers}
 					onClearSelection={clearHighlight}
 				/>
-				<ViewerCanvas
-					scene={scene}
-					highlightOverlay={highlightOverlay}
-					onHighlight={handleHighlight}
-					zoomTrigger={zoomTrigger}
-					onZoomDone={handleZoomDone}
-				/>
+				<div className="absolute inset-0">
+					<ViewerCanvas
+						rootRef={containerRef}
+						isExpanded={isExpanded}
+						scene={scene}
+						highlightOverlay={highlightOverlay}
+						onHighlight={handleHighlight}
+						zoomTrigger={zoomTrigger}
+						onZoomDone={handleZoomDone}
+					/>
+				</div>
 			</div>
 		</>
 	);

--- a/src/app/components/bim-viewer/index.tsx
+++ b/src/app/components/bim-viewer/index.tsx
@@ -7,7 +7,9 @@ import { useZoomControls } from "./hooks/use-zoom-controls";
 import { ViewerCanvas } from "./viewer-canvas";
 import { ViewerOverlay } from "./viewer-overlay";
 import { useGeometryFilter } from "@/app/hooks/use-geometry-filter";
-import { useRef } from "react";
+import { cn } from "@/lib/utils";
+import { useCallback, useRef, useState } from "react";
+import { useExpandedViewer } from "./hooks/use-expanded-viewer";
 
 function LoadingState() {
 	return (
@@ -50,6 +52,13 @@ export function BimViewer({ entityIndices }: { entityIndices: number[] }) {
 	} = useGeometryFilter(entityIndices);
 
 	const containerRef = useRef<HTMLDivElement>(null);
+	const [isExpanded, setIsExpanded] = useState(false);
+	const collapseExpanded = useCallback(() => setIsExpanded(false), []);
+	const toggleExpanded = useCallback(
+		() => setIsExpanded((prev) => !prev),
+		[]
+	);
+	useExpandedViewer(isExpanded, collapseExpanded);
 	const {
 		zoomTrigger,
 		handleZoomToExtent,
@@ -60,34 +69,57 @@ export function BimViewer({ entityIndices }: { entityIndices: number[] }) {
 		setHighlightedEntityIndices,
 	});
 
-	useEscapeKey(containerRef, highlightedEntityIndices, clearHighlight);
+	useEscapeKey(
+		containerRef,
+		highlightedEntityIndices,
+		clearHighlight,
+		isExpanded
+	);
 
 	if (loading) return <LoadingState />;
 	if (error) return <ErrorState message={error.message} />;
 	if (!scene || totalEntityCount === 0) return <NoGeometryState />;
 
 	return (
-		<div ref={containerRef} className="relative w-full h-100" tabIndex={0}>
-			<ViewerOverlay
-				totalEntityCount={totalEntityCount}
-				ghostCount={ghostCount}
-				ghostOthers={ghostOthers}
-				highlightedCount={highlightedEntityIndices.size}
-				entityIndicesLength={entityIndices.length}
-				availableEntityCount={availableEntityCount}
-				zoomTrigger={zoomTrigger}
-				onZoomToExtent={handleZoomToExtent}
-				onZoomToSelected={handleZoomToSelected}
-				onGhostToggle={toggleGhostOthers}
-				onClearSelection={clearHighlight}
-			/>
-			<ViewerCanvas
-				scene={scene}
-				highlightOverlay={highlightOverlay}
-				onHighlight={handleHighlight}
-				zoomTrigger={zoomTrigger}
-				onZoomDone={handleZoomDone}
-			/>
-		</div>
+		<>
+			{isExpanded && (
+				<div
+					className="h-100 w-full shrink-0 rounded border border-dashed border-neutral-300 bg-neutral-50"
+					aria-hidden
+				/>
+			)}
+			<div
+				ref={containerRef}
+				className={cn(
+					"relative w-full outline-none",
+					isExpanded
+						? "fixed inset-0 z-50 h-dvh w-dvw bg-neutral-950"
+						: "h-100"
+				)}
+				tabIndex={0}
+			>
+				<ViewerOverlay
+					totalEntityCount={totalEntityCount}
+					ghostCount={ghostCount}
+					ghostOthers={ghostOthers}
+					highlightedCount={highlightedEntityIndices.size}
+					entityIndicesLength={entityIndices.length}
+					availableEntityCount={availableEntityCount}
+					isExpanded={isExpanded}
+					onToggleExpand={toggleExpanded}
+					onZoomToExtent={handleZoomToExtent}
+					onZoomToSelected={handleZoomToSelected}
+					onGhostToggle={toggleGhostOthers}
+					onClearSelection={clearHighlight}
+				/>
+				<ViewerCanvas
+					scene={scene}
+					highlightOverlay={highlightOverlay}
+					onHighlight={handleHighlight}
+					zoomTrigger={zoomTrigger}
+					onZoomDone={handleZoomDone}
+				/>
+			</div>
+		</>
 	);
 }

--- a/src/app/components/bim-viewer/viewer-canvas.tsx
+++ b/src/app/components/bim-viewer/viewer-canvas.tsx
@@ -29,6 +29,7 @@ export function ViewerCanvas({
 }: ViewerCanvasProps) {
 	return (
 		<Canvas
+			className="h-full w-full"
 			frameloop="demand"
 			shadows
 			gl={{

--- a/src/app/components/bim-viewer/viewer-canvas.tsx
+++ b/src/app/components/bim-viewer/viewer-canvas.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { CanvasResizeSync } from "./canvas-resize-sync";
 import { Scene } from "./scene";
 import { ZoomController } from "./zoom-controller";
+import type { RefObject } from "react";
 import {
 	GizmoHelper,
 	GizmoViewcube,
@@ -13,6 +15,8 @@ import { Canvas } from "@react-three/fiber";
 import * as THREE from "three";
 
 interface ViewerCanvasProps {
+	rootRef: RefObject<HTMLElement | null>;
+	isExpanded: boolean;
 	scene: THREE.Group | null;
 	highlightOverlay: THREE.Group | null;
 	onHighlight: (entityIndex: number, shiftKey: boolean) => void;
@@ -21,6 +25,8 @@ interface ViewerCanvasProps {
 }
 
 export function ViewerCanvas({
+	rootRef,
+	isExpanded,
 	scene,
 	highlightOverlay,
 	onHighlight,
@@ -30,6 +36,7 @@ export function ViewerCanvas({
 	return (
 		<Canvas
 			className="h-full w-full"
+			resize={{ offsetSize: true }}
 			frameloop="demand"
 			shadows
 			gl={{
@@ -38,6 +45,7 @@ export function ViewerCanvas({
 				outputColorSpace: THREE.SRGBColorSpace,
 			}}
 		>
+			<CanvasResizeSync rootRef={rootRef} isExpanded={isExpanded} />
 			<PerspectiveCamera makeDefault position={[50, 50, 50]} fov={50} />
 			<OrbitControls
 				makeDefault

--- a/src/app/components/bim-viewer/viewer-overlay.tsx
+++ b/src/app/components/bim-viewer/viewer-overlay.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
-import { Box, Ghost, Maximize, Focus } from "lucide-react";
+import { Box, Expand, Focus, Ghost, Maximize, Minimize2 } from "lucide-react";
 
 interface EntityCountBadgeProps {
 	totalEntityCount: number;
@@ -71,7 +71,6 @@ export function GhostToggle({ ghostOthers, onClick }: GhostToggleProps) {
 }
 
 interface ZoomControlsProps {
-	zoomTrigger: "extent" | "selected" | null;
 	onZoomToExtent: () => void;
 	onZoomToSelected: () => void;
 	hasSelection: boolean;
@@ -107,6 +106,35 @@ export function ZoomControls({
 	);
 }
 
+interface ExpandViewerControlProps {
+	isExpanded: boolean;
+	onToggle: () => void;
+}
+
+export function ExpandViewerControl({
+	isExpanded,
+	onToggle,
+}: ExpandViewerControlProps) {
+	return (
+		<Button
+			variant="secondary"
+			size="sm"
+			onClick={onToggle}
+			className="gap-1.5 bg-black/70 text-white hover:bg-black/90 border-none"
+			title={isExpanded ? "Exit expanded view (Esc)" : "Expand 3D view"}
+		>
+			{isExpanded ? (
+				<Minimize2 className="h-4 w-4" />
+			) : (
+				<Expand className="h-4 w-4" />
+			)}
+			<span className="sr-only">
+				{isExpanded ? "Exit expanded view" : "Expand 3D view"}
+			</span>
+		</Button>
+	);
+}
+
 interface ViewerOverlayProps {
 	totalEntityCount: number;
 	ghostCount: number;
@@ -114,7 +142,8 @@ interface ViewerOverlayProps {
 	highlightedCount: number;
 	entityIndicesLength: number;
 	availableEntityCount: number;
-	zoomTrigger: "extent" | "selected" | null;
+	isExpanded: boolean;
+	onToggleExpand: () => void;
 	onZoomToExtent: () => void;
 	onZoomToSelected: () => void;
 	onGhostToggle: () => void;
@@ -128,6 +157,8 @@ export function ViewerOverlay({
 	highlightedCount,
 	entityIndicesLength,
 	availableEntityCount,
+	isExpanded,
+	onToggleExpand,
 	onZoomToExtent,
 	onZoomToSelected,
 	onGhostToggle,
@@ -138,7 +169,13 @@ export function ViewerOverlay({
 
 	return (
 		<>
-			<div className="absolute top-2 left-2 z-10 flex gap-2">
+			<div className="absolute top-2 right-2 z-10">
+				<ExpandViewerControl
+					isExpanded={isExpanded}
+					onToggle={onToggleExpand}
+				/>
+			</div>
+			<div className="absolute top-2 left-2 z-10 flex max-w-[calc(100%-3.5rem)] flex-wrap gap-2">
 				<EntityCountBadge
 					totalEntityCount={totalEntityCount}
 					ghostCount={ghostCount}
@@ -146,6 +183,11 @@ export function ViewerOverlay({
 				/>
 				<SelectionBadge count={highlightedCount} onClear={onClearSelection} />
 			</div>
+			{isExpanded && (
+				<div className="pointer-events-none absolute top-14 left-1/2 z-10 -translate-x-1/2 rounded bg-black/60 px-3 py-1 text-xs text-white">
+					Press Esc to exit expanded view
+				</div>
+			)}
 			{showGhostToggle && (
 				<GhostToggle ghostOthers={ghostOthers} onClick={onGhostToggle} />
 			)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **Expand 3D view** for the BIM viewer, plus a fix so the WebGL canvas actually resizes to fill the expanded overlay (not just the chrome around it).

## Changes

- Expand / minimize control on viewer overlay
- Fullscreen overlay layout with Esc to exit
- **`CanvasResizeSync`**: `ResizeObserver` + `setSize()` when toggling expand/collapse
- Canvas layer uses `absolute inset-0` so it fills the viewer bounds

## How to test

1. `pnpm dev` → load sample `.bos` → open a geometry query (e.g. **Render All Geometry**)
2. Click **Expand** — 3D model should fill the screen, not stay letterboxed at embedded size
3. **Esc** or **Minimize** — returns to normal size without breaking the canvas
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b156d28-46c3-4696-8445-868a51776cbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b156d28-46c3-4696-8445-868a51776cbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded viewing mode for the 3D viewer with an expand/collapse button in the top-right.
  * Accessible expand/collapse control with contextual tooltip (“Press Esc to exit expanded view”) when expanded.
  * Canvas now reliably fills and syncs to the viewer container size to avoid clipping.

* **Improvements**
  * Prevent background scrolling while in expanded mode.
  * Overlay layout refined (badge row repositioned, compact controls).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->